### PR TITLE
fix(template(main.go)): template.ParseFiles use precise path

### DIFF
--- a/template/main.go
+++ b/template/main.go
@@ -38,7 +38,7 @@ func main() {
 // indexTemplate is the main site template.
 // The default template includes two template blocks ("sidebar" and "content")
 // that may be replaced in templates derived from this one.
-var indexTemplate = template.Must(template.ParseFiles("index.tmpl"))
+var indexTemplate = template.Must(template.ParseFiles("template/index.tmpl"))
 
 // Index is a data structure used to populate an indexTemplate.
 type Index struct {
@@ -70,7 +70,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 
 // imageTemplate is a clone of indexTemplate that provides
 // alternate "sidebar" and "content" templates.
-var imageTemplate = template.Must(template.Must(indexTemplate.Clone()).ParseFiles("image.tmpl"))
+var imageTemplate = template.Must(template.Must(indexTemplate.Clone()).ParseFiles("template/image.tmpl"))
 
 // Image is a data structure used to populate an imageTemplate.
 type Image struct {


### PR DESCRIPTION
only use filename will cause panic: open index.tmpl: no such file or directory