### PR TITLE
Add Requirements section to README for GO111MODULE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@
 This repository contains a collection of Go programs and libraries that
 demonstrate the language, standard libraries, and tools.
 
+## Requirements
+
+[Golang 1.16 comes with better support for modules](https://blog.golang.org/go116-module-changes) which could case fresh installations of Golang to fail when using the underneath examples.
+
+An failing example could look like this:
+
+```sh
+go get -v -u github.com/golang/example/hello
+
+go get: github.com/golang/example@none updating to
+        github.com/golang/example@v0.0.0-20210113200257-bcf50bfd7dcd: parsing go.mod:
+        module declares its path as: golang.org/x/example
+                but was required as: github.com/golang/example
+```
+
+For that please make sure to configure your Golang module behaviour with following command:
+
+```sh
+go env -w GO111MODULE=auto
+```
+
 ## The examples
 
 ### [hello](hello/) ([godoc](//godoc.org/github.com/golang/example/hello)) and [stringutil](stringutil/) ([godoc](//godoc.org/github.com/golang/example/stringutil))


### PR DESCRIPTION
Hello guys,

I just started out with Golang and one of my books had the example of fetching a module via `go get github.com/golang/example/hello`.
This failed because I freshly installed Golang 1.16 which added the better support for modules.

You can find my example failed command in the added "REQUIREMENTS" section of the README.
I hope this prevents other fresh-starters like me to already fail hard at the begining of the journey until this behaviour changes somehow.