### PR TITLE
fix(template(main.go)): use go:embed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module golang.org/x/example
 
-go 1.15
+go 1.16
 
 require golang.org/x/tools v0.0.0-20210112183307-1e6ecd4bf1b0

--- a/template/main.go
+++ b/template/main.go
@@ -23,6 +23,7 @@ limitations under the License.
 package main
 
 import (
+	"embed"
 	"html/template"
 	"log"
 	"net/http"
@@ -35,10 +36,13 @@ func main() {
 	log.Fatal(http.ListenAndServe("localhost:8080", nil))
 }
 
+//go:embed index.tmpl image.tmpl
+var templateFS embed.FS
+
 // indexTemplate is the main site template.
 // The default template includes two template blocks ("sidebar" and "content")
 // that may be replaced in templates derived from this one.
-var indexTemplate = template.Must(template.ParseFiles("index.tmpl"))
+var indexTemplate = template.Must(template.ParseFS(templateFS, "index.tmpl"))
 
 // Index is a data structure used to populate an indexTemplate.
 type Index struct {
@@ -70,7 +74,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 
 // imageTemplate is a clone of indexTemplate that provides
 // alternate "sidebar" and "content" templates.
-var imageTemplate = template.Must(template.Must(indexTemplate.Clone()).ParseFiles("image.tmpl"))
+var imageTemplate = template.Must(template.Must(indexTemplate.Clone()).ParseFS(templateFS, "image.tmpl"))
 
 // Image is a data structure used to populate an imageTemplate.
 type Image struct {


### PR DESCRIPTION
The new Go1.16 gives us a `go:embed` directive.
This new feature, to my surprise, is not properly represented by the examples in this repository.

I've bumped the version specified by `go.mod` and used `template.ParseFS` instead of `template.ParseFiles` (as portrayed by the article about this awesome feature).