### PR TITLE
add CI pipeline and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Go CI Pipeline
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./outyet
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+
+      - name: Build
+        run: go build -o outyet-app
+
+      - name: Test
+        run: go test ./...
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: outyet-app
+          path: outyet/outyet-app

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>The Multi-stage CI/CD Pipeline</title>
+</head>
+<body>
+<h1>Multi-stage CI/CD Pipeline</h1>
+
+<p>
+    The main purpose of a CI/CD pipeline is to automate the process of building, testing, and preparing code for deployment whenever new changes are introduced.
+    This helps identify errors early, ensures code quality, and makes development more efficient and reliable.
+</p>
+
+<p>In this project, the pipeline follows these stages:</p>
+
+<ul>
+    <li><strong>Checkout:</strong> Retrieves the latest code from the repository to ensure the workflow uses the most up-to-date version.</li>
+    <li><strong>Setup:</strong> Configures the correct Go environment so that the application can be built and tested properly.</li>
+    <li><strong>Build:</strong> Uses <code>go build</code> inside the <code>outyet/</code> directory to compile the code and verify that it can run without syntax errors.</li>
+    <li><strong>Test:</strong> Runs <code>go test</code> to check that all functions behave as expected and that the logic remains correct after any changes.</li>
+    <li><strong>Upload:</strong> If the build is successful, the resulting binary is uploaded as an artifact for future use (e.g., deployment or review).</li>
+</ul>
+
+<p>
+    This type of automation reduces manual effort, minimizes the risk of human error, and speeds up the development workflow by giving quick feedback on every change.
+</p>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a multi-stage CI/CD pipeline using GitHub Actions. The workflow automatically builds and tests the Go project in the `outyet/` directory and uploads the compiled binary as an artifact.

Additionally, a documentation page (`docs/index.html`) was added to explain the purpose and structure of the pipeline.