### PR TITLE
slog-handler-guide: make time regex timezone-aware

### DIFF
--- a/slog-handler-guide/indenthandler1/indent_handler_test.go
+++ b/slog-handler-guide/indenthandler1/indent_handler_test.go
@@ -15,7 +15,7 @@ func Test(t *testing.T) {
 	l := slog.New(New(&buf, nil))
 	l.Info("hello", "a", 1, "b", true, "c", 3.14, slog.Group("g", "h", 1, "i", 2), "d", "NO")
 	got := buf.String()
-	wantre := `time: [-0-9T:.]+Z?
+	wantre := `time: [-0-9T:.]+(Z|[+-][0-9]{2}:[0-9]{2})?
 level: INFO
 source: ".*/indent_handler_test.go:\d+"
 msg: "hello"

--- a/slog-handler-guide/indenthandler2/indent_handler_test.go
+++ b/slog-handler-guide/indenthandler2/indent_handler_test.go
@@ -32,7 +32,7 @@ func Test(t *testing.T) {
 	l := slog.New(New(&buf, nil))
 	l.Info("hello", "a", 1, "b", true, "c", 3.14, slog.Group("g", "h", 1, "i", 2), "d", "NO")
 	got := buf.String()
-	wantre := `time: [-0-9T:.]+Z?
+	wantre := `time: [-0-9T:.]+(Z|[+-][0-9]{2}:[0-9]{2})?
 level: INFO
 source: ".*/indent_handler_test.go:\d+"
 msg: "hello"

--- a/slog-handler-guide/indenthandler3/indent_handler_test.go
+++ b/slog-handler-guide/indenthandler3/indent_handler_test.go
@@ -31,7 +31,7 @@ func Test(t *testing.T) {
 	l := slog.New(New(&buf, nil))
 	l.Info("hello", "a", 1, "b", true, "c", 3.14, slog.Group("g", "h", 1, "i", 2), "d", "NO")
 	got := buf.String()
-	wantre := `time: [-0-9T:.]+Z?
+	wantre := `time: [-0-9T:.]+(Z|[+-][0-9]{2}:[0-9]{2})?
 level: INFO
 source: ".*/indent_handler_test.go:\d+"
 msg: "hello"

--- a/slog-handler-guide/indenthandler4/indent_handler_test.go
+++ b/slog-handler-guide/indenthandler4/indent_handler_test.go
@@ -31,7 +31,7 @@ func Test(t *testing.T) {
 	l := slog.New(New(&buf, nil))
 	l.Info("hello", "a", 1, "b", true, "c", 3.14, slog.Group("g", "h", 1, "i", 2), "d", "NO")
 	got := buf.String()
-	wantre := `time: [-0-9T:.]+Z?
+	wantre := `time: [-0-9T:.]+(Z|[+-][0-9]{2}:[0-9]{2})?
 level: INFO
 source: ".*/indent_handler_test.go:\d+"
 msg: "hello"


### PR DESCRIPTION
The `indenthandler{1..4}` tests assert the log timestamp with the regex `time: [-0-9T:.]+Z?`, which only accepts a UTC `Z` suffix. On hosts with a non-UTC timezone (e.g. `Asia/Shanghai`, UTC+8), `log/slog` emits a numeric offset and the tests fail:

```
--- FAIL: Test (0.00s)
    indent_handler_test.go:32:
        got:
        "time: 2026-08-12T16:00:00.858525+08:00\nlevel: INFO\nsource: \".../indent_handler_test.go:16\"\nmsg: \"hello\"\na: 1\nb: true\n..."
        want:
        "time: [-0-9T:.]+Z?\nlevel: INFO\n..."
```

The `+` sign and the `+08:00` offset are not covered by the `[-0-9T:.]` character class. This change extends the regex to also accept a numeric UTC offset:

```
time: [-0-9T:.]+(Z|[+-][0-9]{2}:[0-9]{2})?
```

Verified on a UTC+8 host: `go test ./slog-handler-guide/...` passes for all four handlers (previously `indenthandler1` and `indenthandler2` failed).
